### PR TITLE
Add return process in non-void function 

### DIFF
--- a/moveit_ros/benchmarks/src/RunBenchmark.cpp
+++ b/moveit_ros/benchmarks/src/RunBenchmark.cpp
@@ -57,5 +57,9 @@ int main(int argc, char** argv)
 
   // Running benchmarks
   if (!server.runBenchmarks(opts))
+  {
     ROS_ERROR("Failed to run all benchmarks");
+    return 1;
+  }
+  return 0;
 }

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -338,7 +338,7 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCompleteState(const std
 
 bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const std::string& group, double wait_time) const
 {
-  waitForCompleteState(group, wait_time);
+  return waitForCompleteState(group, wait_time);
 }
 
 void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state)


### PR DESCRIPTION
### Description
In `RunBenchmark.cpp` and `current_state_monitor.cpp`, the `return` process does not
exist in `main` function and non-void function.
The fix adds `return` and suitable return value.

issue number:#1