### PR TITLE
Fix possibility zero-devide issues.

### DIFF
--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
@@ -148,8 +148,8 @@ int main(int argc, char* argv[])
     if (i != 0)
     {
       ROS_INFO_NAMED("cached_ik.measure_ik_call_cost", "Summary for group %s: %g %g %g", group->getName().c_str(),
-                   ik_time.count() / (double)i, 100. * num_failed_calls / i,
-                   100. * num_self_collisions / (num_self_collisions + i));
+                     ik_time.count() / (double)i, 100. * num_failed_calls / i,
+                     100. * num_self_collisions / (num_self_collisions + i));
     }
     else
     {

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
@@ -145,9 +145,16 @@ int main(int argc, char* argv[])
                        ik_time.count() / (double)i, i, 100. * num_failed_calls / i,
                        100. * num_self_collisions / (num_self_collisions + i));
     }
-    ROS_INFO_NAMED("cached_ik.measure_ik_call_cost", "Summary for group %s: %g %g %g", group->getName().c_str(),
+    if (i != 0)
+    {
+      ROS_INFO_NAMED("cached_ik.measure_ik_call_cost", "Summary for group %s: %g %g %g", group->getName().c_str(),
                    ik_time.count() / (double)i, 100. * num_failed_calls / i,
                    100. * num_self_collisions / (num_self_collisions + i));
+    }
+    else
+    {
+      ROS_WARN_NAMED("cached_ik.measure_ik_call_cost", "fail.");
+    }
   }
 
   ros::shutdown();

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
@@ -95,6 +95,9 @@ double ChompCost::getMaxQuadCostInvValue() const
 
 void ChompCost::scale(double scale)
 {
+  if (scale == 0.0)
+    return;
+
   double inv_scale = 1.0 / scale;
   quad_cost_inv_ *= inv_scale;
   quad_cost_ *= scale;


### PR DESCRIPTION
### Description

Local variables are used as denominator in `measure_ik_call_cost.cpp` and `chomp_optimizer.cpp`.
These variables are initialized with zero and there are cases when they are used without changing value.
This fix adds checking the local variable against zero. (In `chomp_optimizer`, the fix is applied to the function `ChompCost::scale`)

issue number:#2