### PR TITLE
Add safeguards against potential null-pointer dereferencing in moveit_kinematics

### DIFF
--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -228,7 +228,10 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
   for (std::size_t i = 0; i < kdl_chain_.getNrOfSegments(); ++i)
   {
     const robot_model::JointModel* jm = robot_model_->getJointModel(kdl_chain_.segments[i].getJoint().getName());
-
+    if (jm == nullptr)
+    {
+      continue;
+    }
     // first check whether it belongs to the set of active joints in the group
     if (jm->getMimic() == NULL && jm->getVariableCount() > 0)
     {
@@ -258,8 +261,16 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
   {
     if (!mimic_joints[i].active)
     {
-      const robot_model::JointModel* joint_model =
-          joint_model_group->getJointModel(mimic_joints[i].joint_name)->getMimic();
+      const robot_model::JointModel* joint_model = joint_model_group->getJointModel(mimic_joints[i].joint_name);
+      if (joint_model == nullptr)
+      {
+        continue;
+      }
+      joint_model = joint_model->getMimic();
+      if (joint_model == nullptr)
+      {
+        continue;
+      }
       for (std::size_t j = 0; j < mimic_joints.size(); ++j)
       {
         if (mimic_joints[j].joint_name == joint_model->getName())

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -260,8 +260,7 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
   {
     if (!mimic_joints[i].active)
     {
-      const robot_model::JointModel* joint_model =
-          joint_model_group->getJointModel(mimic_joints[i].joint_name);
+      const robot_model::JointModel* joint_model = joint_model_group->getJointModel(mimic_joints[i].joint_name);
       if (joint_model == nullptr)
       {
         continue;

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -227,7 +227,10 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
   for (std::size_t i = 0; i < kdl_chain_.getNrOfSegments(); ++i)
   {
     const robot_model::JointModel* jm = robot_model_->getJointModel(kdl_chain_.segments[i].getJoint().getName());
-
+    if (jm == nullptr)
+    {
+      continue;
+    }
     // first check whether it belongs to the set of active joints in the group
     if (jm->getMimic() == NULL && jm->getVariableCount() > 0)
     {
@@ -258,7 +261,16 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
     if (!mimic_joints[i].active)
     {
       const robot_model::JointModel* joint_model =
-          joint_model_group->getJointModel(mimic_joints[i].joint_name)->getMimic();
+          joint_model_group->getJointModel(mimic_joints[i].joint_name);
+      if (joint_model == nullptr)
+      {
+        continue;
+      }
+      joint_model = joint_model->getMimic();
+      if (joint_model == nullptr)
+      {
+        continue;
+      }
       for (std::size_t j = 0; j < mimic_joints.size(); ++j)
       {
         if (mimic_joints[j].joint_name == joint_model->getName())


### PR DESCRIPTION
### Description

`getJointModel()` return `nullptr` when `joint_model_map` does not have components enclosing the same name argument designate.
In some sources of `moveit_kinematics`, valuables to store `getJointModel()` value refered without checking null-pointer.
This fix adds safeguards and avoiding processes refer to null-pointer. 
And variables refer to `getMimic`, return `mimic_` as member variable are fixed as same as `getJointModel()`. 

issue number:#3