### PR TITLE
Initialize local variables in moveit_kinematics

### DIFF
--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
@@ -95,7 +95,7 @@ public:
     centers.push_back(std::uniform_int_distribution<size_t>{ 0, data.size() - 1 }(generator_));
     for (unsigned i = 1; i < k; ++i)
     {
-      unsigned ind;
+      unsigned ind = (unsigned)data.size();
       const _T& center = data[centers[i - 1]];
       double maxDist = -std::numeric_limits<double>::infinity();
       for (unsigned j = 0; j < data.size(); ++j)

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
@@ -112,7 +112,9 @@ public:
       // no more centers available
       if (maxDist < std::numeric_limits<double>::epsilon())
         break;
-      centers.push_back(ind);
+      if (ind < (unsigned)data.size()) {
+        centers.push_back(ind);
+      }
     }
 
     const _T& center = data[centers.back()];

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
@@ -112,7 +112,8 @@ public:
       // no more centers available
       if (maxDist < std::numeric_limits<double>::epsilon())
         break;
-      if (ind < (unsigned)data.size()) {
+      if (ind < (unsigned)data.size())
+      {
         centers.push_back(ind);
       }
     }

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
@@ -47,8 +47,8 @@ int main(int argc, char* argv[])
 {
   std::string group;
   std::string tip;
-  unsigned int num;
-  bool reset_to_default;
+  unsigned int num = 100000;
+  bool reset_to_default = true;
   po::options_description desc("Options");
   desc.add_options()("help", "show help message")("group", po::value<std::string>(&group)->default_value("all"),
                                                   "name of planning group")(


### PR DESCRIPTION
### Description

Due to using uninitialized local variables, add initializing values to them.
These values based on existing them in same source(default or non-influence value).

issue number:#4