### PR TITLE
Fix missing depth value initialization issue in collision_world_distance_field.

### DIFF
--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -214,7 +214,8 @@ bool getCollisionSphereCollision(const distance_field::DistanceField* distance_f
 bool getCollisionSphereCollision(const distance_field::DistanceField* distance_field,
                                  const std::vector<CollisionSphere>& sphere_list,
                                  const EigenSTL::vector_Vector3d& sphere_centers, double maximum_value,
-                                 double tolerance, unsigned int num_coll, std::vector<unsigned int>& colls);
+                                 double tolerance, unsigned int num_coll, std::vector<unsigned int>& colls,
+                                 std::vector<double>* depths);
 
 // forward declaration required for friending apparently
 class BodyDecompositionVector;

--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -221,9 +221,14 @@ bool collision_detection::getCollisionSphereCollision(const distance_field::Dist
                                                       const std::vector<CollisionSphere>& sphere_list,
                                                       const EigenSTL::vector_Vector3d& sphere_centers,
                                                       double maximum_value, double tolerance, unsigned int num_coll,
-                                                      std::vector<unsigned int>& colls)
+                                                      std::vector<unsigned int>& colls,
+                                                      std::vector<double>* depths)
 {
   colls.clear();
+  if (depths)
+  {
+    depths->clear();
+  }
   for (unsigned int i = 0; i < sphere_list.size(); i++)
   {
     Eigen::Vector3d p = sphere_centers[i];
@@ -243,6 +248,10 @@ bool collision_detection::getCollisionSphereCollision(const distance_field::Dist
       }
 
       colls.push_back(i);
+      if (depths)
+      {
+        depths->push_back(sphere_list[i].radius_ - dist - tolerance);
+      }
       if (colls.size() >= num_coll)
       {
         return true;

--- a/moveit_core/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -273,15 +273,18 @@ bool CollisionRobotDistanceField::getSelfCollisions(const collision_detection::C
     if (req.contacts)
     {
       std::vector<unsigned int> colls;
+      std::vector<double> depths;
       bool coll = getCollisionSphereCollision(
           gsr->dfce_->distance_field_.get(), *collision_spheres_1, *sphere_centers_1, max_propogation_distance_,
-          collision_tolerance_, std::min(req.max_contacts_per_pair, req.max_contacts - res.contact_count), colls);
+          collision_tolerance_, std::min(req.max_contacts_per_pair, req.max_contacts - res.contact_count), colls,
+          &depths);
       if (coll)
       {
         res.collision = true;
         for (unsigned int j = 0; j < colls.size(); j++)
         {
           collision_detection::Contact con;
+          con.depth = depths[j];
           if (is_link)
           {
             con.pos = gsr->link_body_decompositions_[i]->getSphereCenters()[colls[j]];

--- a/moveit_core/collision_distance_field/src/collision_world_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_world_distance_field.cpp
@@ -356,15 +356,18 @@ bool CollisionWorldDistanceField::getEnvironmentCollisions(
     if (req.contacts)
     {
       std::vector<unsigned int> colls;
+      std::vector<double> depths;
       bool coll = getCollisionSphereCollision(
           env_distance_field.get(), *collision_spheres_1, *sphere_centers_1, max_propogation_distance_,
-          collision_tolerance_, std::min(req.max_contacts_per_pair, req.max_contacts - res.contact_count), colls);
+          collision_tolerance_, std::min(req.max_contacts_per_pair, req.max_contacts - res.contact_count), colls,
+          &depths);
       if (coll)
       {
         res.collision = true;
         for (unsigned int j = 0; j < colls.size(); j++)
         {
           Contact con;
+          con.depth = depths[j];
           if (is_link)
           {
             con.pos = gsr->link_body_decompositions_[i]->getSphereCenters()[colls[j]];


### PR DESCRIPTION
### Description

In `collision_world_distance_field.cpp` and `collision_robot_distance_field.cpp`,
a `collision_detection::Contact` is created and stored without initalizing the `.depth` value.
Since `getCollisionSphereCollision()` already calculates the distance of the objects, returning the penetration depth was added as an
optional parameter. (The function is not used anywhere else other than `collision_world_distance_field.cpp` and
`collision_robot_distance_field.cpp`).

issue number:#6