### PR TITLE
Fix potential null-pointer dereferencing issues in moveit_setup_assistant.

### DIFF
--- a/moveit_setup_assistant/src/tools/collision_linear_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.cpp
@@ -128,8 +128,15 @@ QVariant CollisionLinearModel::data(const QModelIndex& index, int role) const
 
 DisabledReason CollisionLinearModel::reason(int row) const
 {
+  CollisionMatrixModel* m = qobject_cast<CollisionMatrixModel*>(sourceModel());
+  if (!m)
+  {
+    Q_ASSERT(m);
+    return moveit_setup_assistant::NOT_DISABLED;
+  }
   QModelIndex srcIndex = this->mapToSource(index(row, 0));
-  return qobject_cast<CollisionMatrixModel*>(sourceModel())->reason(srcIndex);
+
+  return m->reason(srcIndex);
 }
 
 bool CollisionLinearModel::setData(const QModelIndex& index, const QVariant& value, int role)
@@ -238,6 +245,9 @@ void SortFilterProxyModel::setShowAll(bool show_all)
 bool SortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const
 {
   CollisionLinearModel* m = qobject_cast<CollisionLinearModel*>(sourceModel());
+  if (!m)
+    return false;
+
   if (!(show_all_ || m->reason(source_row) <= moveit_setup_assistant::ALWAYS ||
         m->data(m->index(source_row, 2), Qt::CheckStateRole) == Qt::Checked))
     return false;  // not accepted due to check state

--- a/moveit_setup_assistant/src/tools/rotated_header_view.cpp
+++ b/moveit_setup_assistant/src/tools/rotated_header_view.cpp
@@ -78,8 +78,15 @@ QSize RotatedHeaderView::sectionSizeFromContents(int logicalIndex) const
 
   ensurePolished();
 
+  QAbstractItemModel* m = model();
+  if (m == nullptr)
+  {
+    Q_ASSERT(m);
+    return QSize();
+  }
+
   // use SizeHintRole
-  QVariant variant = model()->headerData(logicalIndex, Qt::Vertical, Qt::SizeHintRole);
+  QVariant variant = m->headerData(logicalIndex, Qt::Vertical, Qt::SizeHintRole);
   if (variant.isValid())
     return qvariant_cast<QSize>(variant);
 
@@ -87,7 +94,7 @@ QSize RotatedHeaderView::sectionSizeFromContents(int logicalIndex) const
   QStyleOptionHeader opt;
   initStyleOption(&opt);
   opt.section = logicalIndex;
-  QVariant var = model()->headerData(logicalIndex, orientation(), Qt::FontRole);
+  QVariant var = m->headerData(logicalIndex, orientation(), Qt::FontRole);
   QFont fnt;
   if (var.isValid() && var.canConvert<QFont>())
     fnt = qvariant_cast<QFont>(var);
@@ -95,8 +102,8 @@ QSize RotatedHeaderView::sectionSizeFromContents(int logicalIndex) const
     fnt = font();
   fnt.setBold(true);
   opt.fontMetrics = QFontMetrics(fnt);
-  opt.text = model()->headerData(logicalIndex, orientation(), Qt::DisplayRole).toString();
-  variant = model()->headerData(logicalIndex, orientation(), Qt::DecorationRole);
+  opt.text = m->headerData(logicalIndex, orientation(), Qt::DisplayRole).toString();
+  variant = m->headerData(logicalIndex, orientation(), Qt::DecorationRole);
   opt.icon = qvariant_cast<QIcon>(variant);
   if (opt.icon.isNull())
     opt.icon = qvariant_cast<QPixmap>(variant);
@@ -119,7 +126,10 @@ int RotatedHeaderView::sectionSizeHint(int logicalIndex) const
   if (logicalIndex < 0 || logicalIndex >= count())
     return -1;
   QSize size;
-  QVariant value = model()->headerData(logicalIndex, orientation(), Qt::SizeHintRole);
+  QAbstractItemModel* m = model();
+  if (m == nullptr)
+    return -1;
+  QVariant value = m->headerData(logicalIndex, orientation(), Qt::SizeHintRole);
   if (value.isValid())
     size = qvariant_cast<QSize>(value);
   else

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -423,7 +423,7 @@ void DefaultCollisionsWidget::showHeaderContextMenu(const QPoint& p)
 void DefaultCollisionsWidget::hideSections()
 {
   QList<int> list;
-  QHeaderView* header = 0;
+  QHeaderView* header = nullptr;
   if (clicked_headers_ == Qt::Horizontal)
   {
     for (const QModelIndex& index : selection_model_->selectedColumns())
@@ -444,14 +444,17 @@ void DefaultCollisionsWidget::hideSections()
     list << clicked_section_;
   }
 
-  for (auto index : list)
-    header->setSectionHidden(index, true);
+  if (header != nullptr)
+  {
+    for (auto index : list)
+      header->setSectionHidden(index, true);
+  }
 }
 
 void DefaultCollisionsWidget::hideOtherSections()
 {
   QList<int> list;
-  QHeaderView* header = 0;
+  QHeaderView* header = nullptr;
   if (clicked_headers_ == Qt::Horizontal)
   {
     header = collision_table_->horizontalHeader();
@@ -474,13 +477,16 @@ void DefaultCollisionsWidget::hideOtherSections()
     list << clicked_section_;
   }
 
-  // first hide all sections
-  for (std::size_t index = 0, end = header->count(); index != end; ++index)
-    header->setSectionHidden(index, true);
+  if (header != nullptr)
+  {
+    // first hide all sections
+    for (std::size_t index = 0, end = header->count(); index != end; ++index)
+      header->setSectionHidden(index, true);
 
-  // and subsequently show selected ones
-  for (auto index : list)
-    header->setSectionHidden(index, false);
+    // and subsequently show selected ones
+    for (auto index : list)
+      header->setSectionHidden(index, false);
+  }
 }
 
 void DefaultCollisionsWidget::showSections()
@@ -505,7 +511,7 @@ void DefaultCollisionsWidget::showSections()
     return;
   }
 
-  QHeaderView* header = 0;
+  QHeaderView* header = nullptr;
   if (clicked_headers_ == Qt::Horizontal)
   {
     for (const QModelIndex& index : selection_model_->selectedColumns())
@@ -525,7 +531,11 @@ void DefaultCollisionsWidget::showSections()
     list.clear();
     list << clicked_section_;
   }
-  showSections(header, list);
+
+  if (header != nullptr)
+  {
+    showSections(header, list);
+  }
 }
 void DefaultCollisionsWidget::showSections(QHeaderView* header, const QList<int>& logicalIndexes)
 {
@@ -655,7 +665,8 @@ void DefaultCollisionsWidget::disableControls(bool disable)
 void DefaultCollisionsWidget::checkedFilterChanged()
 {
   SortFilterProxyModel* m = qobject_cast<SortFilterProxyModel*>(model_);
-  m->setShowAll(collision_checkbox_->checkState() == Qt::Checked);
+  if (!m)
+    m->setShowAll(collision_checkbox_->checkState() == Qt::Checked);
 }
 
 // Output Link Pairs to SRDF Format and update the collision matrix

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -665,7 +665,7 @@ void DefaultCollisionsWidget::disableControls(bool disable)
 void DefaultCollisionsWidget::checkedFilterChanged()
 {
   SortFilterProxyModel* m = qobject_cast<SortFilterProxyModel*>(model_);
-  if (!m)
+  if (m != NULL)
     m->setShowAll(collision_checkbox_->checkState() == Qt::Checked);
 }
 

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -316,6 +316,8 @@ void EndEffectorsWidget::edit(const std::string& name)
 
   // Find the selected in datastruture
   srdf::Model::EndEffector* effector = findEffectorByName(name);
+  if (effector == NULL)
+    return;
 
   // Set effector name
   effector_name_field_->setText(effector->name_.c_str());

--- a/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
@@ -206,9 +206,13 @@ bool KinematicChainWidget::addLinkChildRecursive(QTreeWidgetItem* parent, const 
   {
     for (int i = 0; i < parent->childCount(); i++)
     {
-      if (addLinkChildRecursive(parent->child(i), link, parent_name))
+      QTreeWidgetItem* item = parent->child(i);
+      if (item != NULL)
       {
-        return true;
+        if (addLinkChildRecursive(item, link, parent_name))
+        {
+          return true;
+        }
       }
     }
   }

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -87,11 +87,15 @@ void NavigationWidget::setNavs(const QList<QString>& navs)
 
 void NavigationWidget::setEnabled(const int& index, bool enabled)
 {
+  QStandardItem* item = model_->item(index);
+  if (item == nullptr)
+    return;
+
   if (enabled)
-    model_->item(index)->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsDragEnabled |
-                                  Qt::ItemIsDropEnabled | Qt::ItemIsEnabled);
+    item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled |
+                   Qt::ItemIsEnabled);
   else
-    model_->item(index)->setFlags(Qt::NoItemFlags);
+    item->setFlags(Qt::NoItemFlags);
 }
 
 void NavigationWidget::setSelected(const int& index)

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -421,6 +421,8 @@ void RobotPosesWidget::edit(int row)
 
   // Find the selected in datastruture
   srdf::Model::GroupState* pose = findPoseByName(name, group);
+  if (pose == NULL)
+    return;
   current_edit_pose_ = pose;
 
   // Set pose name

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -213,10 +213,13 @@ void SetupAssistantWidget::moveToScreen(const int index)
   {
     // Send the focus lost command to the screen widget
     SetupScreenWidget* ssw = qobject_cast<SetupScreenWidget*>(main_content_->widget(current_index_));
-    if (!ssw->focusLost())
+    if (ssw != NULL)
     {
-      navs_view_->setSelected(current_index_);
-      return;  // switching not accepted
+      if (!ssw->focusLost())
+      {
+        navs_view_->setSelected(current_index_);
+        return;  // switching not accepted
+      }
     }
 
     current_index_ = index;
@@ -229,7 +232,8 @@ void SetupAssistantWidget::moveToScreen(const int index)
 
     // Send the focus given command to the screen widget
     ssw = qobject_cast<SetupScreenWidget*>(main_content_->widget(index));
-    ssw->focusGiven();
+    if (ssw != NULL)
+      ssw->focusGiven();
 
     // Change navigation selected option
     navs_view_->setSelected(index);  // Select first item in list

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -306,6 +306,8 @@ void VirtualJointsWidget::edit(const std::string& name)
 
   // Find the selected in datastruture
   srdf::Model::VirtualJoint* vjoint = findVJointByName(name);
+  if (vjoint == NULL)
+    return;
 
   // Set vjoint name
   vjoint_name_field_->setText(vjoint->name_.c_str());


### PR DESCRIPTION
### Description

`model()` return `nullptr` and `qobject_cast<>` may return zero when this function fail.
Also, In `default_collisions_widget.cpp`, `header` variable is initialized zero. 
The variables refer them are used without checking null and zero.
This fix adds safeguards against null and avoiding processes refer to null.

issue number:#7,#8