### PR TITLE
Fix potential null-pointer dereferencing issues in moveit_core.

### DIFF
--- a/moveit_core/distance_field/src/distance_field.cpp
+++ b/moveit_core/distance_field/src/distance_field.cpp
@@ -209,6 +209,11 @@ bool DistanceField::getShapePoints(const shapes::Shape* shape, const Eigen::Affi
   else
   {
     bodies::Body* body = bodies::createBodyFromShape(shape);
+    if (!body)
+    {
+      ROS_ERROR_NAMED("distance_field", "createBodyFromShape() returned a null pointer");
+      return false;
+    }
     body->setPose(pose);
     findInternalPointsConvex(*body, resolution_, *points);
     delete body;
@@ -293,6 +298,11 @@ void DistanceField::moveShapeInField(const shapes::Shape* shape, const Eigen::Af
     return;
   }
   bodies::Body* body = bodies::createBodyFromShape(shape);
+  if (!body)
+  {
+    ROS_ERROR_NAMED("distance_field", "createBodyFromShape() returned a null pointer");
+    return;
+  }
   body->setPose(old_pose);
   EigenSTL::vector_Vector3d old_point_vec;
   findInternalPointsConvex(*body, resolution_, old_point_vec);
@@ -316,6 +326,11 @@ void DistanceField::moveShapeInField(const shapes::Shape* shape, const geometry_
 void DistanceField::removeShapeFromField(const shapes::Shape* shape, const Eigen::Affine3d& pose)
 {
   bodies::Body* body = bodies::createBodyFromShape(shape);
+  if (!body)
+  {
+    ROS_ERROR_NAMED("distance_field", "createBodyFromShape() returned a null pointer");
+    return;
+  }
   body->setPose(pose);
   EigenSTL::vector_Vector3d point_vec;
   findInternalPointsConvex(*body, resolution_, point_vec);

--- a/moveit_core/distance_field/src/distance_field.cpp
+++ b/moveit_core/distance_field/src/distance_field.cpp
@@ -209,7 +209,7 @@ bool DistanceField::getShapePoints(const shapes::Shape* shape, const Eigen::Affi
   else
   {
     bodies::Body* body = bodies::createBodyFromShape(shape);
-    if (!body)
+    if (body == NULL)
     {
       ROS_ERROR_NAMED("distance_field", "createBodyFromShape() returned a null pointer");
       return false;
@@ -298,7 +298,7 @@ void DistanceField::moveShapeInField(const shapes::Shape* shape, const Eigen::Af
     return;
   }
   bodies::Body* body = bodies::createBodyFromShape(shape);
-  if (!body)
+  if (body == NULL)
   {
     ROS_ERROR_NAMED("distance_field", "createBodyFromShape() returned a null pointer");
     return;
@@ -326,7 +326,7 @@ void DistanceField::moveShapeInField(const shapes::Shape* shape, const geometry_
 void DistanceField::removeShapeFromField(const shapes::Shape* shape, const Eigen::Affine3d& pose)
 {
   bodies::Body* body = bodies::createBodyFromShape(shape);
-  if (!body)
+  if (body == NULL)
   {
     ROS_ERROR_NAMED("distance_field", "createBodyFromShape() returned a null pointer");
     return;

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -571,8 +571,11 @@ bool JointModelGroup::computeIKIndexBijection(const std::vector<std::string>& ik
     if (it == joint_variables_index_map_.end())
     {
       // skip reported fixed joints
-      if (hasJointModel(ik_jnames[i]) && getJointModel(ik_jnames[i])->getType() == JointModel::FIXED)
+      const JointModel* joint_model = getJointModel(ik_jnames[i]);
+      if ((joint_model != nullptr) && (joint_model->getType() == JointModel::FIXED))
+      {
         continue;
+      }
       ROS_ERROR_NAMED("robot_model.jmg", "IK solver computes joint values for joint '%s' "
                                          "but group '%s' does not contain such a joint.",
                       ik_jnames[i].c_str(), getName().c_str());

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -553,9 +553,12 @@ public:
 
   void setJointPositions(const JointModel* joint, const Eigen::Affine3d& transform)
   {
-    joint->computeVariablePositions(transform, position_ + joint->getFirstVariableIndex());
-    markDirtyJointTransforms(joint);
-    updateMimicJoint(joint);
+    if (joint != nullptr)
+    {
+      joint->computeVariablePositions(transform, position_ + joint->getFirstVariableIndex());
+      markDirtyJointTransforms(joint);
+      updateMimicJoint(joint);
+    }
   }
 
   void setJointVelocities(const JointModel* joint, const double* velocity)
@@ -573,6 +576,11 @@ public:
 
   const double* getJointPositions(const JointModel* joint) const
   {
+    if (joint == nullptr)
+    {
+      assert(joint);
+      return position_;
+    }
     return position_ + joint->getFirstVariableIndex();
   }
 

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -494,6 +494,8 @@ void robotStateToStream(const RobotState& state, std::ostream& out,
   for (std::size_t j = 0; j < joint_groups_ordering.size(); ++j)
   {
     const JointModelGroup* jmg = state.getRobotModel()->getJointModelGroup(joint_groups_ordering[j]);
+    if (jmg == nullptr)
+      continue;
 
     // Output name of variables
     if (include_header)

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -235,10 +235,14 @@ void RobotState::setToRandomPositions(const JointModelGroup* group)
   // we do not make calls to RobotModel for random number generation because mimic joints
   // could trigger updates outside the state of the group itself
   random_numbers::RandomNumberGenerator& rng = getRandomNumberGenerator();
+  if (group == NULL)
+    return;
   setToRandomPositions(group, rng);
 }
 void RobotState::setToRandomPositions(const JointModelGroup* group, random_numbers::RandomNumberGenerator& rng)
 {
+  if (group == nullptr)
+    return;
   const std::vector<const JointModel*>& joints = group->getActiveJointModels();
   for (std::size_t i = 0; i < joints.size(); ++i)
     joints[i]->getVariableRandomPositions(rng, position_ + joints[i]->getFirstVariableIndex());
@@ -1418,6 +1422,11 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     ROS_ERROR_NAMED(LOGNAME, "Number of poses must be the same as number of tips");
     return false;
   }
+  if (jmg == nullptr)
+  {
+    ROS_ERROR_NAMED(LOGNAME, "JointModelGroup is none");
+    return false;
+  }
 
   // Load solver
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
@@ -1510,9 +1519,9 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
 
       if (pose_frame != solver_tip_frame)
       {
-        if (hasAttachedBody(pose_frame))
+        const AttachedBody* ab = getAttachedBody(pose_frame);
+        if (ab != nullptr)
         {
-          const AttachedBody* ab = getAttachedBody(pose_frame);
           const EigenSTL::vector_Affine3d& ab_trans = ab->getFixedTransforms();
           if (ab_trans.size() != 1)
           {
@@ -1755,9 +1764,9 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
 
     if (pose_frame != solver_tip_frame)
     {
-      if (hasAttachedBody(pose_frame))
+      const AttachedBody* ab = getAttachedBody(pose_frame);
+      if (ab != nullptr)
       {
-        const AttachedBody* ab = getAttachedBody(pose_frame);
         const EigenSTL::vector_Affine3d& ab_trans = ab->getFixedTransforms();
         if (ab_trans.size() != 1)
         {

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -235,7 +235,7 @@ void RobotState::setToRandomPositions(const JointModelGroup* group)
   // we do not make calls to RobotModel for random number generation because mimic joints
   // could trigger updates outside the state of the group itself
   random_numbers::RandomNumberGenerator& rng = getRandomNumberGenerator();
-  if (group == NULL)
+  if (group == nullptr)
     return;
   setToRandomPositions(group, rng);
 }


### PR DESCRIPTION
### Description

In `distance_field.cpp`, the a variable `body` stored `createBodyFromShape()` value may be null-pointer.
And in other sources of `moveit_core`, similar cases exist.(`getJointModel()` and `getAttachedBody()`)
This fix adds safeguards against null-pointer and avoiding processes refer to null-pointer.

issue number:#9