### PR TITLE
Initialize local variables in moveit_core

### DIFF
--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -748,7 +748,7 @@ bool PropagationDistanceField::readFromStream(std::istream& is)
     {
       for (unsigned int z = 0; z < static_cast<unsigned int>(getZNumCells()); z += 8)
       {
-        char inchar;
+        char inchar = 0;
         if (!in.good())
         {
           return false;


### PR DESCRIPTION
### Description

Due to using uninitialized local variables,add initializing values to them.

issue number:#10