### PR TITLE
Initialize local variables in moveit_planners

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -406,6 +406,10 @@ ompl_interface::ConstraintsLibrary::addConstraintApproximation(
     const ConstraintApproximationConstructionOptions& options)
 {
   ConstraintApproximationConstructionResults res;
+  res.milestones = 0;
+  res.state_sampling_time = 0.0;
+  res.state_connection_time = 0.0;
+  res.sampling_success_rate = 0.0;
   ModelBasedPlanningContextPtr pc = context_manager_.getPlanningContext(group, options.state_space_parameterization);
   if (pc)
   {
@@ -432,6 +436,13 @@ ompl_interface::ConstraintsLibrary::addConstraintApproximation(
     else
       ROS_ERROR_NAMED("constraints_library", "Unable to construct constraint approximation for group '%s'",
                       group.c_str());
+  }
+  else
+  {
+    res.milestones = 0;
+    res.state_sampling_time = 0.0;
+    res.state_connection_time = 0.0;
+    res.sampling_success_rate = 0.0;
   }
   return res;
 }

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -406,10 +406,6 @@ ompl_interface::ConstraintsLibrary::addConstraintApproximation(
     const ConstraintApproximationConstructionOptions& options)
 {
   ConstraintApproximationConstructionResults res;
-  res.milestones = 0;
-  res.state_sampling_time = 0.0;
-  res.state_connection_time = 0.0;
-  res.sampling_success_rate = 0.0;
   ModelBasedPlanningContextPtr pc = context_manager_.getPlanningContext(group, options.state_space_parameterization);
   if (pc)
   {

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -244,7 +244,7 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
           continue;
         }
 
-        double value_d;
+        double value_d = 0.0;
         if (nh_.getParam(group_names[i] + "/" + KNOWN_GROUP_PARAMS[k], value_d))
         {
           // convert to string using no locale
@@ -252,14 +252,14 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
           continue;
         }
 
-        int value_i;
+        int value_i = 0;
         if (nh_.getParam(group_names[i] + "/" + KNOWN_GROUP_PARAMS[k], value_i))
         {
           specific_group_params[KNOWN_GROUP_PARAMS[k]] = std::to_string(value_i);
           continue;
         }
 
-        bool value_b;
+        bool value_b = false;
         if (nh_.getParam(group_names[i] + "/" + KNOWN_GROUP_PARAMS[k], value_b))
         {
           specific_group_params[KNOWN_GROUP_PARAMS[k]] = boost::lexical_cast<std::string>(value_b);


### PR DESCRIPTION
### Description

Due to using uninitialized local variables in structure, add initializing values to them.
These values based on existing them in same source(default or non-influence value).

issue number:#13