### PR TITLE
Fix potential null-pointer dereferencing issues in moveit_ros

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -445,6 +445,10 @@ void RobotState::setJointEfforts(const JointModel* joint, const double* effort)
 
 void RobotState::setJointGroupPositions(const JointModelGroup* group, const double* gstate)
 {
+  if (group == nullptr)
+  {
+    return;
+  }
   const std::vector<int>& il = group->getVariableIndexList();
   if (group->isContiguousWithinState())
     memcpy(position_ + il[0], gstate, group->getVariableCount() * sizeof(double));
@@ -1107,6 +1111,10 @@ Eigen::MatrixXd RobotState::getJacobian(const JointModelGroup* group,
                                         const Eigen::Vector3d& reference_point_position) const
 {
   Eigen::MatrixXd result;
+  if (group == nullptr)
+  {
+    throw Exception("Unable to compute Jacobian");
+  }
   if (!getJacobian(group, group->getLinkModels().back(), reference_point_position, result, false))
     throw Exception("Unable to compute Jacobian");
   return result;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -446,9 +446,8 @@ void RobotState::setJointEfforts(const JointModel* joint, const double* effort)
 void RobotState::setJointGroupPositions(const JointModelGroup* group, const double* gstate)
 {
   if (group == nullptr)
-  {
     return;
-  }
+
   const std::vector<int>& il = group->getVariableIndexList();
   if (group->isContiguousWithinState())
     memcpy(position_ + il[0], gstate, group->getVariableCount() * sizeof(double));
@@ -1112,9 +1111,8 @@ Eigen::MatrixXd RobotState::getJacobian(const JointModelGroup* group,
 {
   Eigen::MatrixXd result;
   if (group == nullptr)
-  {
     throw Exception("Unable to compute Jacobian");
-  }
+
   if (!getJacobian(group, group->getLinkModels().back(), reference_point_position, result, false))
     throw Exception("Unable to compute Jacobian");
   return result;

--- a/moveit_ros/planning/planning_components_tools/src/evaluate_state_operations_speed.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/evaluate_state_operations_speed.cpp
@@ -102,9 +102,19 @@ int main(int argc, char** argv)
     {
       printf("\n");
       const robot_model::JointModelGroup* jmg = robot_model->getJointModelGroup(groups[j]);
+      if (jmg == NULL)
+      {
+        printf("%s: JoingModelGroup is NULL...\n", groups[j].c_str());
+        continue;
+      }
 
       printf("%s: Evaluating FK Random ...\n", groups[j].c_str());
       std::string pname = groups[j] + ":FK Random";
+      if (jmg == NULL)
+      {
+        printf("%s: JoingModelGroup is NULL...\n", groups[j].c_str());
+        continue;
+      }
       for (int i = 0; i < N; ++i)
       {
         moveit::tools::Profiler::Begin(pname);

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -221,9 +221,11 @@ void robot_model_loader::RobotModelLoader::loadKinematicsSolvers(
     const std::map<std::string, double>& timeout = kinematics_loader_->getIKTimeout();
     for (std::map<std::string, double>::const_iterator it = timeout.begin(); it != timeout.end(); ++it)
     {
-      if (!model_->hasJointModelGroup(it->first))
-        continue;
       robot_model::JointModelGroup* jmg = model_->getJointModelGroup(it->first);
+      if (jmg == nullptr)
+      {
+        continue;
+      }
       jmg->setDefaultIKTimeout(it->second);
     }
 
@@ -231,9 +233,11 @@ void robot_model_loader::RobotModelLoader::loadKinematicsSolvers(
     const std::map<std::string, unsigned int>& attempts = kinematics_loader_->getIKAttempts();
     for (std::map<std::string, unsigned int>::const_iterator it = attempts.begin(); it != attempts.end(); ++it)
     {
-      if (!model_->hasJointModelGroup(it->first))
-        continue;
       robot_model::JointModelGroup* jmg = model_->getJointModelGroup(it->first);
+      if (jmg == nullptr)
+      {
+        continue;
+      }
       jmg->setDefaultIKAttempts(it->second);
     }
   }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -112,6 +112,12 @@ public:
     }
 
     joint_model_group_ = getRobotModel()->getJointModelGroup(opt.group_name_);
+    if (joint_model_group_ == nullptr)
+    {
+      std::string error = "Group '" + opt.group_name_ + "' get fail.";
+      ROS_FATAL_STREAM_NAMED("move_group_interface", error);
+      throw std::runtime_error(error);
+    }
 
     joint_state_target_.reset(new robot_state::RobotState(getRobotModel()));
     joint_state_target_->setToDefaultValues();
@@ -1208,7 +1214,8 @@ public:
     if (constraints_storage_)
     {
       moveit_warehouse::ConstraintsWithMetadata msg_m;
-      if (constraints_storage_->getConstraints(msg_m, constraint, robot_model_->getName(), opt_.group_name_))
+      bool bb = constraints_storage_->getConstraints(msg_m, constraint, robot_model_->getName(), opt_.group_name_);
+      if ((bb != false) && msg_m)
       {
         path_constraints_.reset(new moveit_msgs::Constraints(static_cast<moveit_msgs::Constraints>(*msg_m)));
         return true;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -249,7 +249,7 @@ void MotionPlanningDisplay::onInitialize()
   text_display_for_start_ = false;
   text_display_scene_node_->attachObject(text_to_display_);
 
-  if (context_ && context_->getWindowManager() && context_->getWindowManager()->getParentWindow())
+  if (context_->getWindowManager() && context_->getWindowManager()->getParentWindow())
   {
     QShortcut* im_reset_shortcut =
         new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_R), context_->getWindowManager()->getParentWindow());
@@ -1184,9 +1184,15 @@ void MotionPlanningDisplay::onRobotModelLoaded()
 
   dynamics_solver_.clear();
   for (std::size_t i = 0; i < groups.size(); ++i)
-    if (getRobotModel()->getJointModelGroup(groups[i])->isChain())
-      dynamics_solver_[groups[i]].reset(
-          new dynamics_solver::DynamicsSolver(getRobotModel(), groups[i], gravity_vector));
+  {
+    const robot_model::JointModelGroup* jmg = getRobotModel()->getJointModelGroup(groups[i]);
+    if (jmg != nullptr)
+    {
+      if (jmg->isChain())
+        dynamics_solver_[groups[i]].reset(
+            new dynamics_solver::DynamicsSolver(getRobotModel(), groups[i], gravity_vector));
+    }
+  }
   addMainLoopJob(boost::bind(&MotionPlanningDisplay::changedPlanningGroup, this));
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_param_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_param_widget.cpp
@@ -116,6 +116,11 @@ void MotionPlanningParamWidget::changedValue()
   if (!move_group_)
     return;
   rviz::Property* source = qobject_cast<rviz::Property*>(QObject::sender());
+  if (!source)
+  {
+    Q_ASSERT(source);
+    return;
+  }
   std::map<std::string, std::string> params;
   params[source->getName().toStdString()] = source->getValue().toString().toStdString();
   move_group_->setPlannerParams(planner_id_, group_name_, params);

--- a/moveit_ros/warehouse/warehouse/src/initialize_demo_db.cpp
+++ b/moveit_ros/warehouse/warehouse/src/initialize_demo_db.cpp
@@ -110,9 +110,8 @@ int main(int argc, char** argv)
   {
     const robot_model::JointModelGroup* jmg = psm.getRobotModel()->getJointModelGroup(gnames[i]);
     if (jmg == nullptr)
-    {
       continue;
-    }
+
     if (!jmg->isChain())
       continue;
     const std::vector<std::string>& lnames = jmg->getLinkModelNames();

--- a/moveit_ros/warehouse/warehouse/src/initialize_demo_db.cpp
+++ b/moveit_ros/warehouse/warehouse/src/initialize_demo_db.cpp
@@ -109,6 +109,10 @@ int main(int argc, char** argv)
   for (std::size_t i = 0; i < gnames.size(); ++i)
   {
     const robot_model::JointModelGroup* jmg = psm.getRobotModel()->getJointModelGroup(gnames[i]);
+    if (jmg == nullptr)
+    {
+      continue;
+    }
     if (!jmg->isChain())
       continue;
     const std::vector<std::string>& lnames = jmg->getLinkModelNames();


### PR DESCRIPTION
### Description

In some sources of `moveit_ros`, variables which may store null-pointer is used without checking.
This fix adds safeguards and avoiding processes refer to null.

issue number:#14,#15