### PR TITLE
Fix potential null-pointer dereferencing pointer variable issues in moveit_ros

### DIFF
--- a/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
+++ b/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
@@ -121,6 +121,21 @@ void LazyFreeSpaceUpdater::processThread()
     if (!running_)
       break;
 
+    if (!process_occupied_cells_set_ || !process_model_cells_set_)
+    {
+      if (process_occupied_cells_set_)
+      {
+        delete process_occupied_cells_set_;
+        process_occupied_cells_set_ = NULL;
+      }
+      if (process_model_cells_set_)
+      {
+        delete process_model_cells_set_;
+        process_model_cells_set_ = NULL;
+      }
+      continue;
+    }
+
     ROS_DEBUG("Begin processing batched update: marking free cells due to %lu occupied cells and %lu model cells",
               (long unsigned int)process_occupied_cells_set_->size(),
               (long unsigned int)process_model_cells_set_->size());

--- a/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
+++ b/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
@@ -123,16 +123,11 @@ void LazyFreeSpaceUpdater::processThread()
 
     if (!process_occupied_cells_set_ || !process_model_cells_set_)
     {
-      if (process_occupied_cells_set_)
-      {
-        delete process_occupied_cells_set_;
-        process_occupied_cells_set_ = NULL;
-      }
-      if (process_model_cells_set_)
-      {
-        delete process_model_cells_set_;
-        process_model_cells_set_ = NULL;
-      }
+      delete process_occupied_cells_set_;
+      process_occupied_cells_set_ = NULL;
+      delete process_model_cells_set_;
+      process_model_cells_set_ = NULL;
+
       continue;
     }
 


### PR DESCRIPTION
### Description

In `lazy_free_space_updater.cpp`, `process_occupied_cells_set_` and `process_model_cells_set_` are used without checking
null or not null.
This fix adds a safeguard and some processes to continue next iteration.

issue number:#15