### PR TITLE
Initialize member variables by constructor in moveit_ros

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -55,7 +55,6 @@ OcTreeRender::OcTreeRender(const std::shared_ptr<const octomap::OcTree>& octree,
                            Ogre::SceneNode* parent_node = NULL)
   : octree_(octree), scene_manager_(scene_manager), colorFactor_(0.8)
 {
-  scene_manager_ = scene_manager;
   if (!parent_node)
   {
     parent_node = scene_manager_->getRootSceneNode();

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -53,8 +53,9 @@ OcTreeRender::OcTreeRender(const std::shared_ptr<const octomap::OcTree>& octree,
                            OctreeVoxelRenderMode octree_voxel_rendering, OctreeVoxelColorMode octree_color_mode,
                            std::size_t max_octree_depth, Ogre::SceneManager* scene_manager,
                            Ogre::SceneNode* parent_node = NULL)
-  : octree_(octree), colorFactor_(0.8)
+  : octree_(octree), scene_manager_(scene_manager), colorFactor_(0.8)
 {
+  scene_manager_ = scene_manager;
   if (!parent_node)
   {
     parent_node = scene_manager_->getRootSceneNode();


### PR DESCRIPTION
### Description

In `octomap_render.cpp`, member variable `scene_manager_` is uninitialized and used without checking.
This fix adds an initializer its in constructor.
These values based on existing them in same source(default or non-influence value).

issue number:#16