### PR TITLE
Initialize local variables in moveit_ros

### DIFF
--- a/moveit_ros/perception/semantic_world/src/semantic_world.cpp
+++ b/moveit_ros/perception/semantic_world/src/semantic_world.cpp
@@ -299,6 +299,10 @@ SemanticWorld::generatePlacePoses(const object_recognition_msgs::Table& chosen_t
     min_distance_from_edge = cone->radius;
     height_above_table = cone->length / 2.0;
   }
+  else
+  {
+    return place_poses;
+  }
 
   return generatePlacePoses(chosen_table, resolution, height_above_table, delta_height, num_heights,
                             min_distance_from_edge);

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -291,6 +291,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string& group, Intera
         ee.parent_link = eef[i].parent_link_;
         ee.eef_group = eef[i].component_group_;
         ee.interaction = style;
+        ee.size = 0.0;
         active_eef_.push_back(ee);
       }
 
@@ -302,6 +303,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string& group, Intera
       ee.parent_link = jmg->getLinkModelNames().back();
       ee.eef_group = group;
       ee.interaction = style;
+      ee.size = 0.0;
       active_eef_.push_back(ee);
     }
   }
@@ -321,6 +323,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string& group, Intera
           ee.parent_link = eef[i].parent_link_;
           ee.eef_group = eef[i].component_group_;
           ee.interaction = style;
+          ee.size = 0.0;
           active_eef_.push_back(ee);
           break;
         }

--- a/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
@@ -73,8 +73,10 @@ void parseStart(std::istream& in, planning_scene_monitor::PlanningSceneMonitor* 
           if (marker != "=")
             joint = ".";
           else
+          {
             in >> value;
-          v[joint] = value;
+            v[joint] = value;
+          }
           if (joint != ".")
             in >> joint;
         }

--- a/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
@@ -131,7 +131,7 @@ int main(int argc, char** argv)
   std::string host;
 
   int port;
-  float connection_timeout;
+  float connection_timeout = 0.0;
   int connection_retries;
 
   node.param<std::string>("warehouse_host", host, "localhost");


### PR DESCRIPTION
### Description

Due to using uninitialized local variables in structure, add initializing values to them.
These values based on existing them in same source(default or non-influence value).

issue number:#17