### PR TITLE
Fix using uninitialized member variable issues in moveit_kinematics.(Klocwork error)

### DIFF
--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
@@ -101,10 +101,12 @@ public:
                        unsigned int maxNumPtsPerLeaf = 50, unsigned int removedCacheSize = 500,
                        bool rebalancing = false)
     : NearestNeighbors<_T>()
+    , tree_(nullptr)
     , degree_(degree)
     , minDegree_(std::min(degree, minDegree))
     , maxDegree_(std::max(maxDegree, degree))
     , maxNumPtsPerLeaf_(maxNumPtsPerLeaf)
+    , size_(0)
     , rebuildSize_(rebalancing ? maxNumPtsPerLeaf * degree : std::numeric_limits<std::size_t>::max())
     , removedCacheSize_(removedCacheSize)
   {

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -43,11 +43,7 @@
 
 namespace cached_ik_kinematics_plugin
 {
-IKCache::IKCache() :
-    num_joints_(0)
-  , min_pose_distance_(0)
-  , min_config_distance2_(0)
-  , max_cache_size_(0)
+IKCache::IKCache() : num_joints_(0), min_pose_distance_(0), min_config_distance2_(0), max_cache_size_(0)
 {
   // set distance function for nearest-neighbor queries
   ik_nn_.setDistanceFunction([this](const IKEntry* entry1, const IKEntry* entry2) {

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -43,7 +43,11 @@
 
 namespace cached_ik_kinematics_plugin
 {
-IKCache::IKCache()
+IKCache::IKCache() :
+    num_joints_(0)
+  , min_pose_distance_(0)
+  , min_config_distance2_(0)
+  , max_cache_size_(0)
 {
   // set distance function for nearest-neighbor queries
   ik_nn_.setDistanceFunction([this](const IKEntry* entry1, const IKEntry* entry2) {

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -52,7 +52,14 @@ CLASS_LOADER_REGISTER_CLASS(kdl_kinematics_plugin::KDLKinematicsPlugin, kinemati
 
 namespace kdl_kinematics_plugin
 {
-KDLKinematicsPlugin::KDLKinematicsPlugin() : active_(false)
+KDLKinematicsPlugin::KDLKinematicsPlugin()
+  : active_(false)
+  , dimension_(0)
+  , num_possible_redundant_joints_(0)
+  , position_ik_(false)
+  , joint_model_group_(nullptr)
+  , max_solver_iterations_(500.0)
+  , epsilon_(1e-5)
 {
 }
 

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -51,7 +51,14 @@ CLASS_LOADER_REGISTER_CLASS(lma_kinematics_plugin::LMAKinematicsPlugin, kinemati
 
 namespace lma_kinematics_plugin
 {
-LMAKinematicsPlugin::LMAKinematicsPlugin() : active_(false)
+LMAKinematicsPlugin::LMAKinematicsPlugin()
+  : active_(false)
+  , dimension_(0)
+  , num_possible_redundant_joints_(0)
+  , position_ik_(false)
+  , joint_model_group_(nullptr)
+  , max_solver_iterations_(500.0)
+  , epsilon_(1e-5)
 {
 }
 

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -53,7 +53,8 @@ CLASS_LOADER_REGISTER_CLASS(srv_kinematics_plugin::SrvKinematicsPlugin, kinemati
 
 namespace srv_kinematics_plugin
 {
-SrvKinematicsPlugin::SrvKinematicsPlugin() : active_(false)
+SrvKinematicsPlugin::SrvKinematicsPlugin() 
+  : active_(false), dimension_(0), joint_model_group_(nullptr), num_possible_redundant_joints_(0)
 {
 }
 

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -53,7 +53,7 @@ CLASS_LOADER_REGISTER_CLASS(srv_kinematics_plugin::SrvKinematicsPlugin, kinemati
 
 namespace srv_kinematics_plugin
 {
-SrvKinematicsPlugin::SrvKinematicsPlugin() 
+SrvKinematicsPlugin::SrvKinematicsPlugin()
   : active_(false), dimension_(0), joint_model_group_(nullptr), num_possible_redundant_joints_(0)
 {
 }


### PR DESCRIPTION
### Description
Some variables are used without initializing in moveit_kinematics.
This fix adds some initializers to the constructor.

issue number:#39