### PR TITLE
Fix using uninitialized member variable issues in moveit_core.(Klocwork error)

### DIFF
--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -164,7 +164,7 @@ protected:
      *
      * @return
      */
-    JointInfo()
+    JointInfo() : index_(0)
     {
       min_bound_ = -std::numeric_limits<double>::max();
       max_bound_ = std::numeric_limits<double>::max();
@@ -305,6 +305,9 @@ public:
    */
   IKConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name)
     : ConstraintSampler(scene, group_name)
+    , ik_timeout_(0.0)
+    , transform_ik_(false)
+    , need_eef_to_ik_tip_transform_(false)
   {
   }
 

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -304,10 +304,7 @@ public:
    *
    */
   IKConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name)
-    : ConstraintSampler(scene, group_name)
-    , ik_timeout_(0.0)
-    , transform_ik_(false)
-    , need_eef_to_ik_tip_transform_(false)
+    : ConstraintSampler(scene, group_name), ik_timeout_(0.0), transform_ik_(false), need_eef_to_ik_tip_transform_(false)
   {
   }
 

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -592,8 +592,10 @@ private:
 ////////////////////////// inline functions follow ////////////////////////////////////////
 
 inline PropDistanceFieldVoxel::PropDistanceFieldVoxel(int distance_square, int negative_distance_squared)
-  : distance_square_(distance_square), negative_distance_square_(negative_distance_squared)
-  , update_direction_(0), negative_update_direction_(0)
+  : distance_square_(distance_square)
+  , negative_distance_square_(negative_distance_squared)
+  , update_direction_(0)
+  , negative_update_direction_(0)
 {
   closest_point_.x() = PropDistanceFieldVoxel::UNINITIALIZED;
   closest_point_.y() = PropDistanceFieldVoxel::UNINITIALIZED;
@@ -604,8 +606,7 @@ inline PropDistanceFieldVoxel::PropDistanceFieldVoxel(int distance_square, int n
 }
 
 inline PropDistanceFieldVoxel::PropDistanceFieldVoxel()
-  : distance_square_(0), negative_distance_square_(0)
-  , update_direction_(0), negative_update_direction_(0)
+  : distance_square_(0), negative_distance_square_(0), update_direction_(0), negative_update_direction_(0)
 {
 }
 

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -593,6 +593,7 @@ private:
 
 inline PropDistanceFieldVoxel::PropDistanceFieldVoxel(int distance_square, int negative_distance_squared)
   : distance_square_(distance_square), negative_distance_square_(negative_distance_squared)
+  , update_direction_(0), negative_update_direction_(0)
 {
   closest_point_.x() = PropDistanceFieldVoxel::UNINITIALIZED;
   closest_point_.y() = PropDistanceFieldVoxel::UNINITIALIZED;
@@ -603,6 +604,8 @@ inline PropDistanceFieldVoxel::PropDistanceFieldVoxel(int distance_square, int n
 }
 
 inline PropDistanceFieldVoxel::PropDistanceFieldVoxel()
+  : distance_square_(0), negative_distance_square_(0)
+  , update_direction_(0), negative_update_direction_(0)
 {
 }
 

--- a/moveit_core/distance_field/include/moveit/distance_field/voxel_grid.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/voxel_grid.h
@@ -342,7 +342,7 @@ protected:
 template <typename T>
 VoxelGrid<T>::VoxelGrid(double size_x, double size_y, double size_z, double resolution, double origin_x,
                         double origin_y, double origin_z, T default_object)
-  : data_(NULL)
+  : data_(nullptr), data_ptrs_(nullptr)
 {
   resize(size_x, size_y, size_z, resolution, origin_x, origin_y, origin_z, default_object);
 }

--- a/moveit_core/dynamics_solver/src/dynamics_solver.cpp
+++ b/moveit_core/dynamics_solver/src/dynamics_solver.cpp
@@ -66,6 +66,7 @@ inline geometry_msgs::Vector3 transformVector(const Eigen::Affine3d& transform, 
 
 DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr& robot_model, const std::string& group_name,
                                const geometry_msgs::Vector3& gravity_vector)
+  : num_joints_(0), num_segments_(0), gravity_(0.0)
 {
   robot_model_ = robot_model;
   joint_model_group_ = robot_model_->getJointModelGroup(group_name);

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -209,7 +209,10 @@ public:
    * @param [in] model The kinematic model used for constraint evaluation
    */
   JointConstraint(const robot_model::RobotModelConstPtr& model)
-    : KinematicConstraint(model), joint_model_(NULL), joint_variable_index_(-1)
+    : KinematicConstraint(model), joint_model_(NULL)
+    , joint_is_continuous_(false)
+    , joint_variable_index_(-1)
+    , joint_position_(0.0), joint_tolerance_above_(0.0), joint_tolerance_below_(0.0)
   {
     type_ = JOINT_CONSTRAINT;
   }
@@ -357,6 +360,10 @@ public:
    * @param [in] model The kinematic model used for constraint evaluation
    */
   OrientationConstraint(const robot_model::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(NULL)
+    , mobile_frame_(false)
+    , absolute_x_axis_tolerance_(0.0)
+    , absolute_y_axis_tolerance_(0.0)
+    , absolute_z_axis_tolerance_(0.0)
   {
     type_ = ORIENTATION_CONSTRAINT;
   }
@@ -513,7 +520,9 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  PositionConstraint(const robot_model::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(NULL)
+  PositionConstraint(const robot_model::RobotModelConstPtr& model) 
+    : KinematicConstraint(model)
+    , has_offset_(false), mobile_frame_(false), link_model_(NULL)
   {
     type_ = POSITION_CONSTRAINT;
   }

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -209,10 +209,13 @@ public:
    * @param [in] model The kinematic model used for constraint evaluation
    */
   JointConstraint(const robot_model::RobotModelConstPtr& model)
-    : KinematicConstraint(model), joint_model_(NULL)
+    : KinematicConstraint(model)
+    , joint_model_(NULL)
     , joint_is_continuous_(false)
     , joint_variable_index_(-1)
-    , joint_position_(0.0), joint_tolerance_above_(0.0), joint_tolerance_below_(0.0)
+    , joint_position_(0.0)
+    , joint_tolerance_above_(0.0)
+    , joint_tolerance_below_(0.0)
   {
     type_ = JOINT_CONSTRAINT;
   }
@@ -359,7 +362,9 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  OrientationConstraint(const robot_model::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(NULL)
+  OrientationConstraint(const robot_model::RobotModelConstPtr& model)
+    : KinematicConstraint(model)
+    , link_model_(NULL)
     , mobile_frame_(false)
     , absolute_x_axis_tolerance_(0.0)
     , absolute_y_axis_tolerance_(0.0)
@@ -520,9 +525,8 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  PositionConstraint(const robot_model::RobotModelConstPtr& model) 
-    : KinematicConstraint(model)
-    , has_offset_(false), mobile_frame_(false), link_model_(NULL)
+  PositionConstraint(const robot_model::RobotModelConstPtr& model)
+    : KinematicConstraint(model), has_offset_(false), mobile_frame_(false), link_model_(NULL)
   {
     type_ = POSITION_CONSTRAINT;
   }

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -643,12 +643,15 @@ void OrientationConstraint::print(std::ostream& out) const
 }
 
 VisibilityConstraint::VisibilityConstraint(const robot_model::RobotModelConstPtr& model)
-  : KinematicConstraint(model), collision_robot_(new collision_detection::CollisionRobotFCL(model))
-  , mobile_sensor_frame_(false), mobile_target_frame_(false)
+  : KinematicConstraint(model)
+  , collision_robot_(new collision_detection::CollisionRobotFCL(model))
+  , mobile_sensor_frame_(false)
+  , mobile_target_frame_(false)
   , sensor_view_direction_(0)
   , cone_sides_(0)
   , target_radius_(-1.0)
-  , max_view_angle_(0.0), max_range_angle_(0.0)
+  , max_view_angle_(0.0)
+  , max_range_angle_(0.0)
 {
   type_ = VISIBILITY_CONSTRAINT;
 }

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -644,6 +644,11 @@ void OrientationConstraint::print(std::ostream& out) const
 
 VisibilityConstraint::VisibilityConstraint(const robot_model::RobotModelConstPtr& model)
   : KinematicConstraint(model), collision_robot_(new collision_detection::CollisionRobotFCL(model))
+  , mobile_sensor_frame_(false), mobile_target_frame_(false)
+  , sensor_view_direction_(0)
+  , cone_sides_(0)
+  , target_radius_(-1.0)
+  , max_view_angle_(0.0), max_range_angle_(0.0)
 {
   type_ = VISIBILITY_CONSTRAINT;
 }

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -153,7 +153,8 @@ static inline void _robotStateToMultiDOFJointState(const RobotState& state, sens
 class ShapeVisitorAddToCollisionObject : public boost::static_visitor<void>
 {
 public:
-  ShapeVisitorAddToCollisionObject(moveit_msgs::CollisionObject* obj) : boost::static_visitor<void>(), obj_(obj)
+  ShapeVisitorAddToCollisionObject(moveit_msgs::CollisionObject* obj)
+    : boost::static_visitor<void>(), obj_(obj), pose_(nullptr)
   {
   }
 


### PR DESCRIPTION
### Description
Some variables are used without initializing in moveit_core.
This fix adds some initializers to the constructor.

issue number:#40

