### PR TITLE
Fix using uninitialized member variable issues in moveit_ros.(Klocwork error)

### DIFF
--- a/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
@@ -38,7 +38,7 @@
 
 using namespace moveit_ros_benchmarks;
 
-BenchmarkOptions::BenchmarkOptions()
+BenchmarkOptions::BenchmarkOptions() : port_(33829), runs_(10), timeout_(10.0)
 {
 }
 

--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -42,7 +42,7 @@
 #include <eigen_conversions/eigen_msg.h>
 
 move_group::MoveGroupPickPlaceAction::MoveGroupPickPlaceAction()
-  : MoveGroupCapability("PickPlaceAction"), pickup_state_(IDLE)
+  : MoveGroupCapability("PickPlaceAction"), pickup_state_(IDLE), place_state_(IDLE)
 {
 }
 

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
@@ -88,7 +88,7 @@ struct ManipulationPlan
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   ManipulationPlan(const ManipulationPlanSharedDataConstPtr& shared_data)
-    : shared_data_(shared_data), processing_stage_(0)
+    : shared_data_(shared_data), processing_stage_(0), id_(0)
   {
   }
 

--- a/moveit_ros/manipulation/pick_place/src/manipulation_pipeline.cpp
+++ b/moveit_ros/manipulation/pick_place/src/manipulation_pipeline.cpp
@@ -40,7 +40,7 @@
 namespace pick_place
 {
 ManipulationPipeline::ManipulationPipeline(const std::string& name, unsigned int nthreads)
-  : name_(name), nthreads_(nthreads), verbose_(false), stop_processing_(true)
+  : name_(name), nthreads_(nthreads), verbose_(false), empty_queue_threads_(0), stop_processing_(true)
 {
   processing_threads_.resize(nthreads, NULL);
 }

--- a/moveit_ros/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
+++ b/moveit_ros/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
@@ -102,7 +102,7 @@ private:
   std::unique_ptr<LazyFreeSpaceUpdater> free_space_updater_;
 
   std::vector<float> x_cache_, y_cache_;
-  double inv_fx_, inv_fy_, K0_, K2_, K4_, K5_;
+  double K0_, K2_, K4_, K5_;
   std::vector<unsigned int> filtered_labels_;
   ros::WallTime last_depth_callback_start_;
 };

--- a/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -343,16 +343,17 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::ImageConstP
   if (w >= static_cast<int>(x_cache_.size()) || h >= static_cast<int>(y_cache_.size()) || K2_ != px || K5_ != py ||
       K0_ != info_msg->K[0] || K4_ != info_msg->K[4])
   {
+    double inv_fx, inv_fy;
     K2_ = px;
     K5_ = py;
     K0_ = info_msg->K[0];
     K4_ = info_msg->K[4];
 
-    inv_fx_ = 1.0 / K0_;
-    inv_fy_ = 1.0 / K4_;
+    inv_fx = 1.0 / K0_;
+    inv_fy = 1.0 / K4_;
 
     // if there are any NaNs, discard data
-    if (!(px == px && py == py && inv_fx_ == inv_fx_ && inv_fy_ == inv_fy_))
+    if (!(px == px && py == py && inv_fx == inv_fx && inv_fy == inv_fy))
       return;
 
     // Pre-compute some constants
@@ -362,10 +363,10 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::ImageConstP
       y_cache_.resize(h);
 
     for (int x = 0; x < w; ++x)
-      x_cache_[x] = (x - px) * inv_fx_;
+      x_cache_[x] = (x - px) * inv_fx;
 
     for (int y = 0; y < h; ++y)
-      y_cache_[y] = (y - py) * inv_fy_;
+      y_cache_[y] = (y - py) * inv_fy;
   }
 
   const octomap::point3d sensor_origin(map_H_sensor.getOrigin().getX(), map_H_sensor.getOrigin().getY(),

--- a/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_updater.cpp
+++ b/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_updater.cpp
@@ -39,7 +39,7 @@
 
 namespace occupancy_map_monitor
 {
-OccupancyMapUpdater::OccupancyMapUpdater(const std::string& type) : type_(type)
+OccupancyMapUpdater::OccupancyMapUpdater(const std::string& type) : type_(type), monitor_(nullptr), debug_info_(false)
 {
 }
 

--- a/moveit_ros/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
+++ b/moveit_ros/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
@@ -94,7 +94,7 @@ public:
 private:
   struct SeeShape
   {
-    SeeShape()
+    SeeShape() : handle(0), volume(0.0)
     {
       body = NULL;
     }

--- a/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
+++ b/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
@@ -57,7 +57,10 @@ public:
       well as used to read the SRDF document when needed. */
   KinematicsPluginLoader(const std::string& robot_description = "robot_description",
                          double default_search_resolution = 0.0)
-    : robot_description_(robot_description), default_search_resolution_(default_search_resolution)
+    : robot_description_(robot_description)
+    , default_search_resolution_(default_search_resolution)
+    , default_solver_timeout_(0.0)
+    , default_ik_attempts_(0)
   {
   }
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -53,7 +53,7 @@ OcTreeRender::OcTreeRender(const std::shared_ptr<const octomap::OcTree>& octree,
                            OctreeVoxelRenderMode octree_voxel_rendering, OctreeVoxelColorMode octree_color_mode,
                            std::size_t max_octree_depth, Ogre::SceneManager* scene_manager,
                            Ogre::SceneNode* parent_node = NULL)
-  : octree_(octree), colorFactor_(0.8)
+  : octree_(octree), scene_manager_(scene_manager), colorFactor_(0.8)
 {
   if (!parent_node)
   {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
@@ -39,7 +39,14 @@
 
 namespace moveit_rviz_plugin
 {
-TrajectoryPanel::TrajectoryPanel(QWidget* parent) : Panel(parent)
+TrajectoryPanel::TrajectoryPanel(QWidget* parent)
+  : Panel(parent)
+  , slider_(nullptr)
+  , maximum_label_(nullptr)
+  , minimum_label_(nullptr)
+  , button_(nullptr)
+  , paused_(false)
+  , last_way_point_(0)
 {
 }
 


### PR DESCRIPTION
### Description
Some variables are used without initializing in moveit_ros.
This fix adds some initializers to the constructor.

issue number:#38