### PR TITLE
Fix using uninitialized member variable issues in moveit_setup_assistant.(Klocwork error)

### DIFF
--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -53,7 +53,7 @@ namespace fs = boost::filesystem;
 // ******************************************************************************************
 // Constructor
 // ******************************************************************************************
-MoveItConfigData::MoveItConfigData() : config_pkg_generated_timestamp_(0)
+MoveItConfigData::MoveItConfigData() : changes(0), urdf_from_xacro_(false), config_pkg_generated_timestamp_(0)
 {
   // Create an instance of SRDF writer and URDF model for all widgets to share
   srdf_.reset(new srdf::SRDFWriter());

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.h
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.h
@@ -61,6 +61,7 @@ namespace moveit_setup_assistant
 // Custom Type
 enum GroupType
 {
+  INVALID = -1,
   JOINT,
   LINK,
   CHAIN,
@@ -216,7 +217,7 @@ class PlanGroupType
 {
 public:
   //  explicit PlanGroupType();
-  PlanGroupType()
+  PlanGroupType() : group_(NULL), type_(moveit_setup_assistant::INVALID)
   {
   }
   PlanGroupType(srdf::Model::Group* group, const moveit_setup_assistant::GroupType type);


### PR DESCRIPTION
### Description
Some variables are used without initializing in moveit_setup_assistant.
This fix adds some initializers to the constructor.

issue number:#37