### PR TITLE
Fix memory leak issues in moveit_setup_assistant.(Klocwork error)

### DIFF
--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -566,6 +566,7 @@ void EndEffectorsWidget::doneEditing()
   if (isNew)
   {
     config_data_->srdf_->end_effectors_.push_back(*searched_data);
+    delete searched_data;
   }
 
   // Finish up ------------------------------------------------------

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -696,6 +696,7 @@ void RobotPosesWidget::doneEditing()
   if (isNew)
   {
     config_data_->srdf_->group_states_.push_back(*searched_data);
+    delete searched_data;
   }
 
   // Finish up ------------------------------------------------------

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -527,6 +527,7 @@ void VirtualJointsWidget::doneEditing()
     if (searched_data->child_link_ == config_data_->getRobotModel()->getRootLinkName())
       emit_frame_notice = true;
     config_data_->srdf_->virtual_joints_.push_back(*searched_data);
+    delete searched_data;
     config_data_->updateRobotModel();
   }
 


### PR DESCRIPTION
### Description
Some variables are not deleted which causes a memory leak.
This fix adds `delete` to the functions which have variables without deleting. 

issue number:#36