### PR TITLE
Fix memory leak issues in moveit_ros.(Klocwork error)

### DIFF
--- a/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
+++ b/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
@@ -199,6 +199,10 @@ void LazyFreeSpaceUpdater::processThread()
     delete process_model_cells_set_;
     process_model_cells_set_ = NULL;
   }
+  delete process_occupied_cells_set_;
+  process_occupied_cells_set_ = NULL;
+  delete process_model_cells_set_;
+  process_model_cells_set_ = NULL;
 }
 
 void LazyFreeSpaceUpdater::lazyUpdateThread()
@@ -262,6 +266,12 @@ void LazyFreeSpaceUpdater::lazyUpdateThread()
       occupied_cells_set = NULL;
       batch_size = 0;
     }
+  }
+
+  if (batch_size != 0)
+  {
+    delete occupied_cells_set;
+    delete model_cells_set;
   }
 }
 }

--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -69,6 +69,7 @@ rdf_loader::RDFLoader::RDFLoader(const std::string& robot_description)
   if (!umodel->initString(content))
   {
     ROS_ERROR_NAMED("rdf_loader", "Unable to parse URDF from parameter '%s'", robot_description_.c_str());
+    delete umodel;
     return;
   }
   urdf_.reset(umodel);


### PR DESCRIPTION
### Description
Some variables are not deleted which causes a memory leak.
This fix adds `delete` to the functions which have variables without deleting. 

issue number:#42