### PR TITLE
Fix using uninitialized member variable issues in moveit_plugins.(Klocwork error)

### DIFF
--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -106,7 +106,7 @@ bool LastPointController::waitForExecution(const ros::Duration&)
 
 ThreadedController::ThreadedController(const std::string& name, const std::vector<std::string>& joints,
                                        const ros::Publisher& pub)
-  : BaseFakeController(name, joints, pub)
+  : BaseFakeController(name, joints, pub), cancel_(false)
 {
 }
 


### PR DESCRIPTION
### Description
Some variables are used without initializing in moveit_plugins.
This fix adds some initializers to the constructor.

issue number:#43