### PR TITLE
Add the initializer to the constructor of class FilterJob

### DIFF
--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/filter_job.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/filter_job.h
@@ -90,7 +90,7 @@ template <typename ReturnType>
 class FilterJob : public Job
 {
 public:
-  FilterJob(const boost::function<ReturnType()>& exec) : Job(), exec_(exec)
+  FilterJob(const boost::function<ReturnType()>& exec) : Job(), exec_(exec), result_(ReturnType())
   {
   }
   virtual void execute();


### PR DESCRIPTION
### Description
In class FilterJob, member variable result_ is uninitialized and used without checking.
This fix adds an initializer its in constructor.

issue : #46